### PR TITLE
feat: add max_time argument

### DIFF
--- a/code/expes/max-time.py
+++ b/code/expes/max-time.py
@@ -1,0 +1,61 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from benchopt.datasets import make_correlated_data
+from libsvmdata import fetch_libsvm
+from scipy import stats
+
+from slope.solvers import hybrid_cd, oracle_cd, prox_grad
+from slope.utils import dual_norm_slope
+
+dataset = "real-sim"
+if dataset == "simulated":
+    X, y, _ = make_correlated_data(n_samples=100, n_features=40, random_state=0)
+    # X = csc_matrix(X)
+else:
+    X, y = fetch_libsvm(dataset)
+
+randnorm = stats.norm(loc=0, scale=1)
+q = 0.5
+
+alphas_seq = randnorm.ppf(1 - np.arange(1, X.shape[1] + 1) * q / (2 * X.shape[1]))
+
+
+alpha_max = dual_norm_slope(X, y / len(y), alphas_seq)
+
+alphas = alpha_max * alphas_seq / 5
+plt.close("all")
+
+max_epochs = 10000
+tol = 1e-10
+max_time = 3
+
+beta_cd, primals_cd, gaps_cd, time_cd = hybrid_cd(
+    X, y, alphas, max_epochs=max_epochs, verbose=True, tol=tol, max_time=max_time
+)
+beta_pgd, primals_pgd, gaps_pgd, time_pgd = prox_grad(
+    X,
+    y,
+    alphas,
+    max_epochs=max_epochs,
+    verbose=True,
+    tol=tol,
+    fista=True,
+    max_time=max_time,
+)
+beta_oracle, primals_oracle, gaps_oracle, time_oracle = oracle_cd(
+    X, y, alphas, max_epochs=max_epochs, verbose=True, tol=tol, max_time=max_time
+)
+
+plt.clf()
+
+primal_star = np.min([np.min(primals_oracle), np.min(primals_pgd), np.min(primals_cd)])
+
+plt.semilogy(time_cd, primals_cd - primal_star, label="cd")
+plt.semilogy(time_pgd, primals_pgd - primal_star, label="pgd")
+plt.semilogy(time_oracle, primals_oracle - primal_star, label="oracle")
+
+plt.ylabel("suboptimality")
+plt.xlabel("time (s)")
+plt.legend()
+plt.title(dataset)
+plt.show(block=False)

--- a/code/slope/solvers/hybrid.py
+++ b/code/slope/solvers/hybrid.py
@@ -109,6 +109,7 @@ def hybrid_cd(
     y,
     alphas,
     max_epochs=1000,
+    max_time=np.Inf,
     cluster_updates=False,
     verbose=True,
     tol=1e-3,
@@ -180,9 +181,11 @@ def hybrid_cd(
         gaps.append(gap)
         times.append(timer() - time_start)
 
+        times_up = timer() - time_start > max_time
+
         if verbose:
             print(f"Epoch: {epoch + 1}, loss: {primal}, gap: {gap:.2e}")
-        if gap < tol:
+        if gap < tol or times_up:
             break
 
     return w, E, gaps, times

--- a/code/slope/solvers/oracle.py
+++ b/code/slope/solvers/oracle.py
@@ -48,7 +48,7 @@ def pure_cd_epoch_sparse(
         R += (old - beta_tilde) * sum_X
 
 
-def oracle_cd(X, y, alphas, max_epochs, tol=1e-10, verbose=False):
+def oracle_cd(X, y, alphas, max_epochs, tol=1e-10, max_time=np.Inf, verbose=False):
     """Oracle CD: get solution clusters and run CD on collapsed design."""
     n_samples, n_features = X.shape
     w_star = prox_grad(X, y, alphas, max_epochs=10000, tol=1e-10)[0]
@@ -108,9 +108,11 @@ def oracle_cd(X, y, alphas, max_epochs, tol=1e-10, verbose=False):
         gaps.append(gap)
         times.append(timer() - time_start)
 
+        times_up = timer() - time_start > max_time
+
         if verbose:
             print(f"Epoch: {epoch + 1}, loss: {primal}, gap: {gap:.2e}")
-        if gap < tol:
+        if gap < tol or times_up:
             break
 
     return w, E, gaps, times


### PR DESCRIPTION
This is a small pull request that adds the ability to stop the solver after a maximum time has passed. It's useful for debugging but also for experiments where you don't want to wait for slow-running solvers to finish (and anyway will have to crop the resulting plot).

Capped at 3 seconds here:

![image](https://user-images.githubusercontent.com/13087841/171475133-df1e30d4-4782-4d70-9a4e-fdd93a2846c9.png)
