### PR TITLE
Add w_star argument to oracle_cd

### DIFF
--- a/code/slope/solvers/oracle.py
+++ b/code/slope/solvers/oracle.py
@@ -48,10 +48,12 @@ def pure_cd_epoch_sparse(
         R += (old - beta_tilde) * sum_X
 
 
-def oracle_cd(X, y, alphas, max_epochs, tol=1e-10, max_time=np.Inf, verbose=False):
+def oracle_cd(X, y, alphas, max_epochs, tol=1e-10, max_time=np.Inf, verbose=False,
+              w_star=None):
     """Oracle CD: get solution clusters and run CD on collapsed design."""
     n_samples, n_features = X.shape
-    w_star = prox_grad(X, y, alphas, max_epochs=10000, tol=1e-10)[0]
+    if w_star is None:
+        w_star = prox_grad(X, y, alphas, max_epochs=10000, tol=1e-10)[0]
     clusters, cluster_ptr, unique = get_clusters(w_star)
     n_clusters = len(cluster_ptr) - 1
     is_X_sparse = sparse.issparse(X)


### PR DESCRIPTION
This PR adds the possibility to give w_star to the oracle_cd. This is useful for benchopt comparison where the w_star can be computed once and for all. 