### PR TITLE
feat: add line search for hybrid method

### DIFF
--- a/code/expes/hybrid-line-search.py
+++ b/code/expes/hybrid-line-search.py
@@ -31,17 +31,6 @@ tol = 1e-6
 beta_cd_ls, primals_cd_ls, gaps_cd_ls, time_cd_ls = hybrid_cd(
     X, y, alphas, max_epochs=max_epochs, verbose=True, tol=tol, line_search=True, max_time=max_time
 )
-beta_cd_bb, primals_cd_bb, gaps_cd_bb, time_cd_bb = hybrid_cd(
-    X,
-    y,
-    alphas,
-    max_epochs=max_epochs,
-    verbose=True,
-    tol=tol,
-    line_search=True,
-    use_bb=True,
-    max_time=max_time
-)
 
 beta_cd, primals_cd, gaps_cd, time_cd = hybrid_cd(
     X, y, alphas, max_epochs=max_epochs, verbose=True, tol=tol, line_search=False,max_time=max_time
@@ -51,7 +40,6 @@ plt.clf()
 
 plt.semilogy(time_cd, gaps_cd, label="cd")
 plt.semilogy(time_cd_ls, gaps_cd_ls, label="cd_ls")
-plt.semilogy(time_cd_bb, gaps_cd_bb, label="cd_bb")
 
 plt.legend()
 plt.title(f"{dataset}, reg: {reg}, q: {q}")

--- a/code/slope/solvers/hybrid.py
+++ b/code/slope/solvers/hybrid.py
@@ -127,7 +127,6 @@ def hybrid_cd(
     cluster_updates=False,
     update_zero_cluster=False,
     line_search=True,
-    use_bb=True,
     verbose=True,
     tol=1e-3,
     pgd_freq=5
@@ -155,34 +154,15 @@ def hybrid_cd(
     # line search parameter
     eta = 2.0
 
-    # BB parameters
-    gamma = 2.0
-    prev_bb = 1.0
-    w_old = w
-    grad_old = grad
-
     E, gaps = [], []
     E.append(norm(y)**2 / (2 * n_samples))
     gaps.append(E[0])
     for epoch in range(max_epochs):
         if epoch % pgd_freq == 0:
-            if epoch > 0 and use_bb:
-                grad_old = grad.copy()
             grad = -(X.T @ R) / n_samples
             if line_search:
                 f_old = norm(R) ** 2 / (2 * n_samples)
-                if use_bb and epoch > 0:
-                    delta_w = w - w_old
-                    delta_grad = grad - grad_old
-
-                    # BB step size safe-guarding
-                    delta_w_grad_dot = delta_w @ delta_grad
-                    bb1 = (norm(delta_w) ** 2) / delta_w_grad_dot
-                    bb2 = delta_w_grad_dot / (norm(delta_grad) ** 2)
-
-                    bb = bb2 if bb1 < gamma * bb2 else bb1 - bb2 / gamma
-                    L = 1.0 / bb if bb > 0 else 1.0 / prev_bb
-                    prev_bb = bb
+                L *= 0.9
 
                 w_old = w.copy()
 


### PR DESCRIPTION
This PR adds support for a line search procedure to the hybrid solver for the PGD step. The reason for why we'd want this instead of estimating L directly is because we don't really use L that often, which means that it may not be worthwhile do compute it when it's expensive to do so and also because L is awkward to estimate when X is sparse and you want an intercept. As you can see in #15 it's typically just more effective by itself too. But the results here actually do not always agree with that finding.

And I actually think we should just use line search exclusively and drop the code for the direct computation of L, but I'm not sure everyone else would agree?

I initially considered more fancy stuff like the BB rule but I don't think it really makes any sense here.

![image](https://user-images.githubusercontent.com/13087841/171821887-acf7d2ac-96e5-4999-afe3-32c5122e6071.png)

![image](https://user-images.githubusercontent.com/13087841/171822291-7ea2e8cb-e6a4-4e60-8d11-565685fcd136.png)

![image](https://user-images.githubusercontent.com/13087841/171822831-dd5b8cae-b798-4225-a885-a09f954c2ad9.png)

![image](https://user-images.githubusercontent.com/13087841/171823129-7d719838-71a0-46bf-83f0-35d4393c606d.png)

![image](https://user-images.githubusercontent.com/13087841/171824699-9a5c9c3c-208e-4d23-ae5b-0ac58ee0ec37.png)





