### PR TITLE
feat: add preprocessing function

### DIFF
--- a/code/expes/test_strategy.py
+++ b/code/expes/test_strategy.py
@@ -4,8 +4,8 @@ from benchopt.datasets import make_correlated_data
 from scipy import stats
 
 from slope.data import get_data
-from slope.solvers import hybrid_cd, oracle_cd, prox_grad
-from slope.utils import dual_norm_slope
+from slope.solvers import admm, hybrid_cd, prox_grad
+from slope.utils import dual_norm_slope, preprocess
 
 dataset = "bcTCGA"
 if dataset == "simulated":
@@ -14,22 +14,23 @@ if dataset == "simulated":
 else:
     X, y = get_data(dataset)
 
+X, y = preprocess(X, y)
+
 fit_intercept = True
 
 randnorm = stats.norm(loc=0, scale=1)
 q = 0.1
-reg = 0.01
+reg = 0.1
 
 alphas_seq = randnorm.ppf(1 - np.arange(1, X.shape[1] + 1) * q / (2 * X.shape[1]))
 
 alpha_max = dual_norm_slope(X, (y - fit_intercept * np.mean(y)) / len(y), alphas_seq)
 
 alphas = alpha_max * alphas_seq * reg
-plt.close("all")
 
 max_epochs = 10000
 max_time = 120
-tol = 1e-6
+tol = 1e-8
 
 beta_cd, intercept_cd, primals_cd, gaps_cd, time_cd = hybrid_cd(
     X,
@@ -41,7 +42,8 @@ beta_cd, intercept_cd, primals_cd, gaps_cd, time_cd = hybrid_cd(
     tol=tol,
     max_time=max_time,
 )
-beta_pgd, intercept_cd, primals_pgd, gaps_pgd, time_pgd = prox_grad(
+
+beta_pgd, intercept_pgd, primals_pgd, gaps_pgd, time_pgd = prox_grad(
     X,
     y,
     alphas,
@@ -51,7 +53,8 @@ beta_pgd, intercept_cd, primals_pgd, gaps_pgd, time_pgd = prox_grad(
     tol=tol,
     fista=True,
 )
-beta_oracle, intercept_cd, primals_oracle, gaps_oracle, time_oracle = oracle_cd(
+
+beta_admm, intercept_admm, primals_admm, gaps_admm, time_admm = admm(
     X,
     y,
     alphas,
@@ -61,33 +64,12 @@ beta_oracle, intercept_cd, primals_oracle, gaps_oracle, time_oracle = oracle_cd(
     tol=tol,
 )
 
-plt.clf()
-
-plt.semilogy(gaps_cd, label="cd")
-plt.semilogy(gaps_pgd, label="pgd")
-plt.semilogy(gaps_oracle, label="oracle")
-
-plt.legend()
-plt.title(dataset)
-plt.show(block=False)
-
-# Duality gap vs epoch for hybrid vs oracle
-plt.clf()
-
-plt.semilogy(np.arange(len(gaps_cd)), primals_cd - primals_pgd[-1], label="cd")
-plt.semilogy(
-    np.arange(len(gaps_oracle)), primals_oracle - primals_pgd[-1], label="oracle"
-)
-
-plt.legend()
-plt.show(block=False)
-
 # Time vs. duality gap
 plt.clf()
 
 plt.semilogy(time_cd, gaps_cd, label="cd")
 plt.semilogy(time_pgd, gaps_pgd, label="pgd")
-plt.semilogy(time_oracle, gaps_oracle, label="oracle")
+plt.semilogy(time_admm, gaps_admm, label="admm")
 
 plt.ylabel("duality gap")
 plt.xlabel("Time (s)")

--- a/code/slope/utils.py
+++ b/code/slope/utils.py
@@ -3,6 +3,7 @@ import scipy.sparse as sparse
 from numba import njit
 from numpy.linalg import norm
 from scipy import stats
+from sklearn import feature_selection, preprocessing
 from sklearn.isotonic import isotonic_regression
 
 
@@ -191,3 +192,20 @@ def add_intercept_column(X):
         return sparse.hstack((sparse.csc_array(np.ones((n, 1))), X), format="csc")
     else:
         return np.hstack((np.ones((n, 1)), X))
+
+
+def preprocess(X, y, standardize_X=True, standardize_y=True, remove_zero_var=True):
+    if remove_zero_var:
+        X = feature_selection.VarianceThreshold().fit_transform(X)
+
+    if standardize_y:
+        y -= np.mean(y)
+        y /= np.linalg.norm(y) ** 2
+
+    if standardize_X:
+        if sparse.issparse(X):
+            X = preprocessing.MaxAbsScaler().fit_transform(X).to_csc()
+        else:
+            X = preprocessing.StandardScaler().fit_transform(X)
+
+    return X, y


### PR DESCRIPTION
This PR adds a function `preprocess` that preprocess X and y. Zero variance features are removed from X. If X is sparse it is then we scale using `MaxAbsScaler`. If it is dense we scale using `StandardScaler`. y is centered and scaled by it's squared norm.

I'm not sure if we should handle y like this. Let me know what you think.

Maybe it makes more sense to put this function into the benchopt benchmark instead. What do you think?