### PR TITLE
refactor: use our own prox implementation

### DIFF
--- a/code/slope/solvers/newtalm.py
+++ b/code/slope/solvers/newtalm.py
@@ -7,14 +7,14 @@ from scipy.linalg import cho_factor, cho_solve, norm, solve
 from scipy.sparse.linalg import cg, spsolve
 
 import slope.permutation as slopep
-from slope.utils import add_intercept_column, prox_slope2, ConvergenceMonitor
+from slope.utils import ConvergenceMonitor, add_intercept_column, prox_slope
 
 
 def build_W(x_tilde, sigma, lambdas, A, fit_intercept):
     m = A.shape[0]
 
     ord = np.argsort(np.abs(x_tilde[fit_intercept:]))[::-1]
-    x_lambda = np.abs(prox_slope2(x_tilde[fit_intercept:], lambdas)[ord])
+    x_lambda = np.abs(prox_slope(x_tilde[fit_intercept:], lambdas)[ord])
 
     z = slopep.BBT_inv_B(np.abs(x_tilde[fit_intercept:][ord]) - lambdas - x_lambda)
 
@@ -45,7 +45,7 @@ def psi(y, x, ATy, b, lambdas, sigma, fit_intercept):
     w = x - sigma * ATy
     u = np.zeros(len(w))
     u[fit_intercept:] = (1 / sigma) * (
-        w[fit_intercept:] - prox_slope2(w[fit_intercept:], lambdas * sigma)
+        w[fit_intercept:] - prox_slope(w[fit_intercept:], lambdas * sigma)
     )
     if fit_intercept:
         u[0] = 0.0
@@ -65,7 +65,7 @@ def compute_direction(x, sigma, A, b, y, ATy, lambdas, cg_param, solver, fit_int
     x_tilde = x / sigma - ATy
 
     x_tilde_prox = x - sigma * ATy
-    x_tilde_prox[fit_intercept:] = prox_slope2(
+    x_tilde_prox[fit_intercept:] = prox_slope(
         x_tilde_prox[fit_intercept:], sigma * lambdas
     )
 
@@ -199,7 +199,7 @@ def inner_step(
 
     # step 2, update x
     x = x_old - sigma * ATy
-    x[fit_intercept:] = prox_slope2(x[fit_intercept:], sigma * lambdas)
+    x[fit_intercept:] = prox_slope(x[fit_intercept:], sigma * lambdas)
 
     # check for convergence
     x_diff_norm = norm(x - x_old)

--- a/code/slope/utils.py
+++ b/code/slope/utils.py
@@ -5,7 +5,6 @@ import scipy.sparse as sparse
 from numba import njit
 from numpy.linalg import norm
 from scipy import stats
-from sklearn.isotonic import isotonic_regression
 
 
 @njit
@@ -48,23 +47,9 @@ def lambda_sequence(X, y, fit_intercept, reg=0.1, q=0.1):
     return lambda_max * lambdas * reg
 
 
-def prox_slope(w, alphas):
-    w_abs = np.abs(w)
-    idx = np.argsort(w_abs)[::-1]
-    w_abs = w_abs[idx]
-    # projection onto Km+
-    w_abs = isotonic_regression(w_abs - alphas, y_min=0, increasing=False)
-
-    # undo the sorting
-    inv_idx = np.zeros_like(idx)
-    inv_idx[idx] = np.arange(len(w))
-
-    return np.sign(w) * w_abs[inv_idx]
-
-
 @njit
-def prox_slope2(beta, lambdas):
-    """Compute the sorted L1 proximal operator
+def prox_slope(beta, lambdas):
+    """Compute the sorted L1 proximal operator.
 
     Parameters
     ----------


### PR DESCRIPTION
We are currently using two versions of the prox: one which we have coded
manually (prox2) and one which is based on isotonic regression from sklearn.
Because of how things are coded, we need to use the manual one in the
implementation for NewtALM for numba to work.

We may as well just drop the other implementation since they are equally fast.
